### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $curlOptions = array(
     CURLOPT_SSL_VERIFYPEER => true
 );
 $soapClient = new \Camcima\Soap\Client($wsdl, $options);
-$soapClient->setCurlOptions($curlOptionsFixture);
+$soapClient->setCurlOptions($curlOptions);
 ```
 
 There are a few cURL options, however, that can't be overwritten as they are essential for the wrapper:


### PR DESCRIPTION
Sample referenced `$curlOptionsFixture` in the code, but should have just been `$curlOptions`.
