### PR TITLE
Fix package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "camcima/soap-client",
+    "name": "camcima/camcima-soap-client",
     "description": "Wrapper around PHP SoapClient class",
 	"keywords": ["library", "soap", "client", "wrapper", "webservice", "wsdl", "soapclient"],
     "type": "library",


### PR DESCRIPTION
$ sudo composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)                 
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - camcima/mundipagg-php-client dev-master requires camcima/camcima-soap-client dev-master -> no matching package found.
    - camcima/mundipagg-php-client dev-master requires camcima/camcima-soap-client dev-master -> no matching package found.
    - Installation request for camcima/mundipagg-php-client dev-master -> satisfiable by camcima/mundipagg-php-client[dev-master].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.