### PR TITLE
add an option to avoid SSL verify peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ This is my attempt to address the shortcommings of the native PHP SOAP Client im
 
 ```php
 <?php
-$soapClient = new \Camcima\Soap\Client($wsdl, $options);
+$soapClient = new \Camcima\Soap\Client($wsdl, $options, $sslVerifyPeer);
 ```
+
+The default value of sslVerifyPeer is `true`, which means that SSL certificate will be verified.  If WSDL file is hosted on a server that has an invalid SSL certificate or self-signed certificate, set `sslVerifyPeer` to `false`.
 
 ### cURL Options ###
 

--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -120,8 +120,20 @@ class Client extends \SoapClient
      * @param string $wsdl
      * @param array $options
      */
-    function __construct($wsdl, array $options = array())
+    function __construct($wsdl, array $options = array(), $sslVerifyPeer = true)
     {
+        if (!$sslVerifyPeer)
+        {
+            $stream_context = stream_context_create(array(
+                'ssl' => array(
+                    'verify_peer'       => false,
+                    'verify_peer_name'  => false,
+                    'allow_self_signed' => true
+                    )
+                ));
+            $options['stream_context'] = $stream_context;
+        }
+        
         parent::__construct($wsdl, $options);
         $this->soapOptions = $options;
         $this->curlOptions = array();

--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -119,6 +119,7 @@ class Client extends \SoapClient
      * 
      * @param string $wsdl
      * @param array $options
+     * @param bool $sslVerifyPeer
      */
     function __construct($wsdl, array $options = array(), $sslVerifyPeer = true)
     {


### PR DESCRIPTION
Sometimes, we want to access a WSDL file via HTTPS, and its SSL certificate is self-signed.  In this case, we will need to set SSL Verify Peer option to false.  Otherwise, \SoapClient::SoapClient() constructor will reject this WSDL with the following error.

SOAP-ERROR: Parsing WSDL: Couldn't load from 'https://somehost/some?wsdl' : failed to load external entity "https://somehost/some?wsdl"
 in /somewhere/camcima-soap-client/src/Camcima/Soap/Client.php on line 125