### PR TITLE
fix: changing WSDL url when is over SSL

### DIFF
--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -132,6 +132,8 @@ class Client extends \SoapClient
      */
     protected $soapOptions = array();
 
+    protected $wsdlOverSsl = false;
+
     /**
      * Client constructor.
      * @param $wsdl
@@ -142,6 +144,12 @@ class Client extends \SoapClient
      */
     function __construct($wsdl, array $options = array(), $sslVerifyPeer = true, $debugMode = false, $keepNullProperties = true)
     {
+        $wsdlParsed = parse_url($wsdl);
+
+        if($wsdlParsed['scheme'] == 'https') {
+            $this->wsdlOverSsl = true;
+        }
+
         if ($sslVerifyPeer === false) {
             $stream_context = stream_context_create(array(
                 'ssl' => array(
@@ -220,6 +228,11 @@ class Client extends \SoapClient
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
+        if($this->wsdlOverSsl) {
+            // just to insure the request will be maybe over SSL
+            $location = preg_replace("/^http:/i", "https:", $location);
+        }
+
         $userAgent = $this->getUserAgent();
         $contentType = $this->getContentType();
 


### PR DESCRIPTION
The SOAP library is defined by default to make requests in the HTTP protocol. When an SSL URL is given, the PHP core changes the protocol internally to HTTP, breaking the communication.

This change fix that, in the construction of the client, we check if the WSDL is over the SSL protocol, if so, in the `__doRequest` method, we change the protocol from HTTP to HTTPS, so the cURL can be executed correctly.