### PR TITLE
fix: remove deprecated warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"keywords": ["library", "soap", "client", "wrapper", "webservice", "wsdl", "soapClient"],
     "type": "library",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1",
         "lib-curl": "*",
         "ext-libxml": "*",
         "ext-soap": "*"

--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -218,6 +218,7 @@ class Client extends \SoapClient
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function __doRequest($request, $location, $action, $version, $one_way = 0) : ?string
     {
         $userAgent = $this->getUserAgent();
@@ -313,6 +314,7 @@ class Client extends \SoapClient
 	/**
 	 * {@inheritDoc}
 	 */
+    #[ReturnTypeWillChange]
 	public function __setCookie( $name, $value = null ) : void
 	{
 		$this->cookies[ $name ] = $value;
@@ -605,7 +607,7 @@ class Client extends \SoapClient
      */
     private function hasProxyConfigured()
     {
-        return (strlen($this->proxyHost) > 0);
+        return ($this->proxyHost !== '');
     }
 
     /**

--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -218,7 +218,7 @@ class Client extends \SoapClient
     /**
      * {@inheritDoc}
      */
-    public function __doRequest($request, $location, $action, $version, $one_way = 0)
+    public function __doRequest($request, $location, $action, $version, $one_way = 0) : ?string
     {
         $userAgent = $this->getUserAgent();
         $contentType = $this->getContentType();
@@ -313,7 +313,7 @@ class Client extends \SoapClient
 	/**
 	 * {@inheritDoc}
 	 */
-	public function __setCookie( $name, $value = null )
+	public function __setCookie( $name, $value = null ) : void
 	{
 		$this->cookies[ $name ] = $value;
 	}

--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -132,8 +132,6 @@ class Client extends \SoapClient
      */
     protected $soapOptions = array();
 
-    protected $wsdlOverSsl = false;
-
     /**
      * Client constructor.
      * @param $wsdl
@@ -144,12 +142,6 @@ class Client extends \SoapClient
      */
     function __construct($wsdl, array $options = array(), $sslVerifyPeer = true, $debugMode = false, $keepNullProperties = true)
     {
-        $wsdlParsed = parse_url($wsdl);
-
-        if($wsdlParsed['scheme'] == 'https') {
-            $this->wsdlOverSsl = true;
-        }
-
         if ($sslVerifyPeer === false) {
             $stream_context = stream_context_create(array(
                 'ssl' => array(
@@ -228,11 +220,6 @@ class Client extends \SoapClient
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
-        if($this->wsdlOverSsl) {
-            // just to insure the request will be maybe over SSL
-            $location = preg_replace("/^http:/i", "https:", $location);
-        }
-
         $userAgent = $this->getUserAgent();
         $contentType = $this->getContentType();
 

--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -132,6 +132,8 @@ class Client extends \SoapClient
      */
     protected $soapOptions = array();
 
+    protected $wsdlOverSsl = false;
+
     /**
      * Client constructor.
      * @param $wsdl
@@ -142,6 +144,12 @@ class Client extends \SoapClient
      */
     function __construct($wsdl, array $options = array(), $sslVerifyPeer = true, $debugMode = false, $keepNullProperties = true)
     {
+        $wsdlParsed = parse_url($wsdl);
+
+        if($wsdlParsed['scheme'] == 'https') {
+            $this->wsdlOverSsl = true;
+        }
+
         if ($sslVerifyPeer === false) {
             $stream_context = stream_context_create(array(
                 'ssl' => array(
@@ -220,6 +228,11 @@ class Client extends \SoapClient
      */
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
+        if($this->wsdlOverSsl) {
+            // just to insure the request will be maybe over SSL
+            $location = preg_replace("/^http:/i", "https:", $location);
+        }
+
         $userAgent = $this->getUserAgent();
         $contentType = $this->getContentType();
 


### PR DESCRIPTION
### Problema 📝

Se han identificado y abordado los warnings de soporte para PHP 8.1 en el cliente de soap client.